### PR TITLE
KRA-691 - iframe audio issues

### DIFF
--- a/src/globals.d.ts
+++ b/src/globals.d.ts
@@ -35,8 +35,6 @@ declare const customEvents: import('typed-emitter').default<{
   'kradle:followPlayer' (data: any): void // request from kradle to follow a player
   'kradle:reconnect' (data: any): void // request from kradle to reconnect
   'kradle:setAgentSkins' (data: any): void // request from kradle to setAgentSkins
-  'kradle:setVolume' (data: any): void // request from kradle to setVolume level
-  'kradle:setMusic' (data: any): void // request from kradle to setMusic on/off
   connectionStatus (statusData: {
     status: 'connected' | 'connecting' | 'disconnected' | 'error' | 'kicked'
     message: string

--- a/src/iframe.ts
+++ b/src/iframe.ts
@@ -30,7 +30,7 @@ type IFrameSendablePayload =
     canReconnect: boolean; // Whether reconnection is possible
   }
 
-type ReceivableActions = 'followPlayer' | 'command' | 'reconnect' | 'setAgentSkins' | 'setVolume' | 'setMusic'
+type ReceivableActions = 'followPlayer' | 'command' | 'reconnect' | 'setAgentSkins'
 
 export function setupIframeComms () {
   // Handle incoming messages from kradle frontend
@@ -110,31 +110,6 @@ export function setupIframeComms () {
           // Primary mapping: username -> skinUrl
           window.agentSkinMap.set(agentSkin.username, agentSkin.skinUrl)
         }
-      }
-    }
-  })
-
-  // Handle volume control from parent app
-  customEvents.on('kradle:setVolume', (data) => {
-    if (typeof data.volume === 'number') {
-      const clampedVolume = Math.max(0, Math.min(100, data.volume))
-      options.volume = clampedVolume
-    }
-  })
-
-  // Handle music toggle from parent app
-  customEvents.on('kradle:setMusic', (data) => {
-    if (typeof data.enabled === 'boolean') {
-      options.enableMusic = data.enabled
-
-      if (data.enabled) {
-        // If music is being turned on, try to start it
-        if (window.forceStartMusic) {
-          window.forceStartMusic()
-        }
-      } else {
-        // If music is being turned off, stop current music
-        musicSystem.stopMusic()
       }
     }
   })

--- a/src/optionsStorage.ts
+++ b/src/optionsStorage.ts
@@ -24,7 +24,7 @@ const defaultOptions = {
   chatOpacity: isDev ? 50 : 0, // show chat in dev
   chatOpacityOpened: 100,
   messagesLimit: 200,
-  volume: 30,
+  volume: 0,
   enableMusic: true,
   // fov: 70,
   fov: 75,

--- a/src/react/AudioControls.tsx
+++ b/src/react/AudioControls.tsx
@@ -1,0 +1,230 @@
+import { useState, useRef, useEffect, CSSProperties, PointerEvent } from "react";
+import PixelartIcon from "./PixelartIcon";
+import { options } from "../optionsStorage";
+import { musicSystem } from "../sounds/musicSystem";
+
+declare global {
+  interface Window {
+    webkitAudioContext?: typeof AudioContext;
+    forceStartMusic?: () => void;
+    __ignorePointerLock?: boolean;
+  }
+}
+
+export default function AudioControls() {
+  const [volume, setVolume] = useState<number>(options.volume ?? 50);
+  const [musicEnabled, setMusicEnabled] = useState<boolean>(options.enableMusic ?? true);
+  const [isInteracting, setIsInteracting] = useState<boolean>(false);
+  const audioContextRef = useRef<AudioContext | null>(null);
+
+  // --- helpers ---
+  const resumeAudioContext = () => {
+    if (!audioContextRef.current) {
+      const Ctx = window.AudioContext || window.webkitAudioContext;
+      audioContextRef.current = new Ctx();
+    }
+    if (audioContextRef.current.state === "suspended") {
+      void audioContextRef.current.resume();
+    }
+  };
+
+  const exitPointerLock = () => {
+    if (document.pointerLockElement) {
+      document.exitPointerLock?.();
+    }
+  };
+
+  useEffect(() => {
+    const handler = () => {
+      if (document.pointerLockElement && isInteracting) exitPointerLock();
+    };
+    document.addEventListener("pointerlockchange", handler);
+    return () => document.removeEventListener("pointerlockchange", handler);
+  }, [isInteracting]);
+
+  const beginInteraction = () => {
+    setIsInteracting(true);
+    delayPointerReacquire();
+    window.__ignorePointerLock = true;
+    exitPointerLock();
+  };
+
+  const endInteraction = () => {
+    setIsInteracting(false);
+    window.__ignorePointerLock = false;
+  };
+
+  const delayPointerReacquire = () => {
+    window.__ignorePointerLock = true;
+    setTimeout(() => {
+      window.__ignorePointerLock = false;
+    }, 500);
+  };
+
+  const changeVolume = (delta: number) => {
+    const newVolume = Math.max(0, Math.min(100, volume + delta));
+    setVolume(newVolume);
+    options.volume = newVolume;
+    resumeAudioContext();
+  };
+
+  const toggleMusic = () => {
+    const newState = !musicEnabled;
+    setMusicEnabled(newState);
+    options.enableMusic = newState;
+    resumeAudioContext();
+
+    if (newState) {
+      window.forceStartMusic?.();
+    } else {
+      musicSystem.stopMusic();
+    }
+  };
+
+  // --- layout constants ---
+  const ICON_WRAP = 14;
+  const GLYPH = 10;
+  const GAP = 4;
+
+  const getVolumeIconName = (v: number): string => {
+    if (v <= 0) return "volume-x";
+    if (v <= 33) return "volume-1";
+    if (v <= 66) return "volume-2";
+    return "volume-3";
+  };
+
+  const makeButtonStyle = (extra?: CSSProperties): CSSProperties => ({
+    width: `${ICON_WRAP}px`,
+    height: `${ICON_WRAP}px`,
+    padding: 0,
+    boxSizing: "border-box",
+    display: "flex",
+    alignItems: "center",
+    justifyContent: "center",
+    background: "rgba(255,255,255,0.10)",
+    border: "1px solid rgba(255,255,255,0.14)",
+    borderRadius: "4px",
+    cursor: "pointer",
+    ...extra,
+  });
+
+  const containerStyle: CSSProperties = {
+    position: "absolute",
+    bottom: "5px",
+    right: "5px",
+    zIndex: 1000,
+    display: "flex",
+    alignItems: "center",
+    gap: `${GAP}px`,
+    padding: "3px 6px",
+    background: "rgba(0,0,0,0.65)",
+    borderRadius: "6px",
+    color: "white",
+    fontFamily: '"VT323", monospace',
+    fontSize: "11px",
+    lineHeight: 1,
+    pointerEvents: "auto",
+    userSelect: "none",
+  };
+
+  // --- component ---
+  return (
+    <>
+      <style>
+        {`
+          .audio-icon-fix {
+            display: inline-flex;
+            align-items: center;
+            justify-content: center;
+            width: 10px;
+            height: 10px;
+            font-size: 10px;
+            line-height: 1;
+            vertical-align: middle;
+            transform: translateY(-0.2px);
+          }
+          .audio-icon-muted {
+            opacity: 0.4;
+            filter: grayscale(100%);
+          }
+        `}
+      </style>
+
+      <div
+        style={containerStyle}
+        onPointerDown={(e: PointerEvent<HTMLDivElement>) => {
+          e.stopPropagation();
+          beginInteraction();
+        }}
+        onPointerUp={(e: PointerEvent<HTMLDivElement>) => {
+          e.stopPropagation();
+          endInteraction();
+        }}
+      >
+        {/* volume icon */}
+        <div
+          style={{
+            width: ICON_WRAP,
+            height: ICON_WRAP,
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "center",
+          }}
+        >
+          <PixelartIcon
+            iconName={getVolumeIconName(volume)}
+            className="audio-icon-fix"
+            width={GLYPH}
+          />
+        </div>
+
+        {/* volume down */}
+        <button
+          title="Volume down"
+          onClick={(e) => {
+            e.stopPropagation();
+            changeVolume(-10);
+          }}
+          style={makeButtonStyle()}
+        >
+          <PixelartIcon iconName="minus" className="audio-icon-fix" width={GLYPH} />
+        </button>
+
+        {/* volume percent */}
+        <div style={{ minWidth: "28px", textAlign: "center" }}>{volume}%</div>
+
+        {/* volume up */}
+        <button
+          title="Volume up"
+          onClick={(e) => {
+            e.stopPropagation();
+            changeVolume(10);
+          }}
+          style={makeButtonStyle()}
+        >
+          <PixelartIcon iconName="plus" className="audio-icon-fix" width={GLYPH} />
+        </button>
+
+        {/* music toggle */}
+        <button
+          title={musicEnabled ? "Turn music off" : "Turn music on"}
+          onClick={(e) => {
+            e.stopPropagation();
+            toggleMusic();
+          }}
+          style={makeButtonStyle(
+            musicEnabled
+              ? { border: "1px solid rgba(180,220,255,0.6)" }
+              : undefined
+          )}
+        >
+          <PixelartIcon
+            iconName="music"
+            className={`audio-icon-fix ${!musicEnabled ? "audio-icon-muted" : ""}`}
+            width={GLYPH}
+          />
+        </button>
+      </div>
+    </>
+  );
+}

--- a/src/react/AudioControls.tsx
+++ b/src/react/AudioControls.tsx
@@ -1,131 +1,131 @@
-import { useState, useRef, useEffect, CSSProperties, PointerEvent } from "react";
-import PixelartIcon from "./PixelartIcon";
-import { options } from "../optionsStorage";
-import { musicSystem } from "../sounds/musicSystem";
+import { useState, useRef, useEffect, CSSProperties, PointerEvent } from 'react'
+import { options } from '../optionsStorage'
+import { musicSystem } from '../sounds/musicSystem'
+import PixelartIcon from './PixelartIcon'
 
 declare global {
   interface Window {
-    webkitAudioContext?: typeof AudioContext;
-    forceStartMusic?: () => void;
-    __ignorePointerLock?: boolean;
+    webkitAudioContext?: typeof AudioContext
+    forceStartMusic?: () => void
+    __ignorePointerLock?: boolean
   }
 }
 
-export default function AudioControls() {
-  const [volume, setVolume] = useState<number>(options.volume ?? 50);
-  const [musicEnabled, setMusicEnabled] = useState<boolean>(options.enableMusic ?? true);
-  const [isInteracting, setIsInteracting] = useState<boolean>(false);
-  const audioContextRef = useRef<AudioContext | null>(null);
+export default function AudioControls () {
+  const [volume, setVolume] = useState<number>(options.volume ?? 50)
+  const [musicEnabled, setMusicEnabled] = useState<boolean>(options.enableMusic ?? true)
+  const [isInteracting, setIsInteracting] = useState<boolean>(false)
+  const audioContextRef = useRef<AudioContext | null>(null)
 
   // --- helpers ---
   const resumeAudioContext = () => {
     if (!audioContextRef.current) {
-      const Ctx = window.AudioContext || window.webkitAudioContext;
-      audioContextRef.current = new Ctx();
+      const Ctx = window.AudioContext || window.webkitAudioContext
+      audioContextRef.current = new Ctx()
     }
-    if (audioContextRef.current.state === "suspended") {
-      void audioContextRef.current.resume();
+    if (audioContextRef.current.state === 'suspended') {
+      void audioContextRef.current.resume()
     }
-  };
+  }
 
   const exitPointerLock = () => {
     if (document.pointerLockElement) {
-      document.exitPointerLock?.();
+      document.exitPointerLock?.()
     }
-  };
+  }
 
   useEffect(() => {
     const handler = () => {
-      if (document.pointerLockElement && isInteracting) exitPointerLock();
-    };
-    document.addEventListener("pointerlockchange", handler);
-    return () => document.removeEventListener("pointerlockchange", handler);
-  }, [isInteracting]);
+      if (document.pointerLockElement && isInteracting) exitPointerLock()
+    }
+    document.addEventListener('pointerlockchange', handler)
+    return () => document.removeEventListener('pointerlockchange', handler)
+  }, [isInteracting])
 
   const beginInteraction = () => {
-    setIsInteracting(true);
-    delayPointerReacquire();
-    window.__ignorePointerLock = true;
-    exitPointerLock();
-  };
+    setIsInteracting(true)
+    delayPointerReacquire()
+    window.__ignorePointerLock = true
+    exitPointerLock()
+  }
 
   const endInteraction = () => {
-    setIsInteracting(false);
-    window.__ignorePointerLock = false;
-  };
+    setIsInteracting(false)
+    window.__ignorePointerLock = false
+  }
 
   const delayPointerReacquire = () => {
-    window.__ignorePointerLock = true;
+    window.__ignorePointerLock = true
     setTimeout(() => {
-      window.__ignorePointerLock = false;
-    }, 500);
-  };
+      window.__ignorePointerLock = false
+    }, 500)
+  }
 
   const changeVolume = (delta: number) => {
-    const newVolume = Math.max(0, Math.min(100, volume + delta));
-    setVolume(newVolume);
-    options.volume = newVolume;
-    resumeAudioContext();
-  };
+    const newVolume = Math.max(0, Math.min(100, volume + delta))
+    setVolume(newVolume)
+    options.volume = newVolume
+    resumeAudioContext()
+  }
 
   const toggleMusic = () => {
-    const newState = !musicEnabled;
-    setMusicEnabled(newState);
-    options.enableMusic = newState;
-    resumeAudioContext();
+    const newState = !musicEnabled
+    setMusicEnabled(newState)
+    options.enableMusic = newState
+    resumeAudioContext()
 
     if (newState) {
-      window.forceStartMusic?.();
+      window.forceStartMusic?.()
     } else {
-      musicSystem.stopMusic();
+      musicSystem.stopMusic()
     }
-  };
+  }
 
   // --- layout constants ---
-  const ICON_WRAP = 14;
-  const GLYPH = 10;
-  const GAP = 4;
+  const ICON_WRAP = 14
+  const GLYPH = 10
+  const GAP = 4
 
   const getVolumeIconName = (v: number): string => {
-    if (v <= 0) return "volume-x";
-    if (v <= 33) return "volume-1";
-    if (v <= 66) return "volume-2";
-    return "volume-3";
-  };
+    if (v <= 0) return 'volume-x'
+    if (v <= 33) return 'volume-1'
+    if (v <= 66) return 'volume-2'
+    return 'volume-3'
+  }
 
   const makeButtonStyle = (extra?: CSSProperties): CSSProperties => ({
     width: `${ICON_WRAP}px`,
     height: `${ICON_WRAP}px`,
     padding: 0,
-    boxSizing: "border-box",
-    display: "flex",
-    alignItems: "center",
-    justifyContent: "center",
-    background: "rgba(255,255,255,0.10)",
-    border: "1px solid rgba(255,255,255,0.14)",
-    borderRadius: "4px",
-    cursor: "pointer",
+    boxSizing: 'border-box',
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    background: 'rgba(255,255,255,0.10)',
+    border: '1px solid rgba(255,255,255,0.14)',
+    borderRadius: '4px',
+    cursor: 'pointer',
     ...extra,
-  });
+  })
 
   const containerStyle: CSSProperties = {
-    position: "absolute",
-    bottom: "5px",
-    right: "5px",
+    position: 'absolute',
+    bottom: '5px',
+    right: '5px',
     zIndex: 1000,
-    display: "flex",
-    alignItems: "center",
+    display: 'flex',
+    alignItems: 'center',
     gap: `${GAP}px`,
-    padding: "3px 6px",
-    background: "rgba(0,0,0,0.65)",
-    borderRadius: "6px",
-    color: "white",
+    padding: '3px 6px',
+    background: 'rgba(0,0,0,0.65)',
+    borderRadius: '6px',
+    color: 'white',
     fontFamily: '"VT323", monospace',
-    fontSize: "11px",
+    fontSize: '11px',
     lineHeight: 1,
-    pointerEvents: "auto",
-    userSelect: "none",
-  };
+    pointerEvents: 'auto',
+    userSelect: 'none',
+  }
 
   // --- component ---
   return (
@@ -153,12 +153,12 @@ export default function AudioControls() {
       <div
         style={containerStyle}
         onPointerDown={(e: PointerEvent<HTMLDivElement>) => {
-          e.stopPropagation();
-          beginInteraction();
+          e.stopPropagation()
+          beginInteraction()
         }}
         onPointerUp={(e: PointerEvent<HTMLDivElement>) => {
-          e.stopPropagation();
-          endInteraction();
+          e.stopPropagation()
+          endInteraction()
         }}
       >
         {/* volume icon */}
@@ -166,65 +166,65 @@ export default function AudioControls() {
           style={{
             width: ICON_WRAP,
             height: ICON_WRAP,
-            display: "flex",
-            alignItems: "center",
-            justifyContent: "center",
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center',
           }}
         >
           <PixelartIcon
             iconName={getVolumeIconName(volume)}
-            className="audio-icon-fix"
+            className='audio-icon-fix'
             width={GLYPH}
           />
         </div>
 
         {/* volume down */}
         <button
-          title="Volume down"
+          title='Volume down'
           onClick={(e) => {
-            e.stopPropagation();
-            changeVolume(-10);
+            e.stopPropagation()
+            changeVolume(-10)
           }}
           style={makeButtonStyle()}
         >
-          <PixelartIcon iconName="minus" className="audio-icon-fix" width={GLYPH} />
+          <PixelartIcon iconName='minus' className='audio-icon-fix' width={GLYPH} />
         </button>
 
         {/* volume percent */}
-        <div style={{ minWidth: "28px", textAlign: "center" }}>{volume}%</div>
+        <div style={{ minWidth: '28px', textAlign: 'center' }}>{volume}%</div>
 
         {/* volume up */}
         <button
-          title="Volume up"
+          title='Volume up'
           onClick={(e) => {
-            e.stopPropagation();
-            changeVolume(10);
+            e.stopPropagation()
+            changeVolume(10)
           }}
           style={makeButtonStyle()}
         >
-          <PixelartIcon iconName="plus" className="audio-icon-fix" width={GLYPH} />
+          <PixelartIcon iconName='plus' className='audio-icon-fix' width={GLYPH} />
         </button>
 
         {/* music toggle */}
         <button
-          title={musicEnabled ? "Turn music off" : "Turn music on"}
+          title={musicEnabled ? 'Turn music off' : 'Turn music on'}
           onClick={(e) => {
-            e.stopPropagation();
-            toggleMusic();
+            e.stopPropagation()
+            toggleMusic()
           }}
           style={makeButtonStyle(
             musicEnabled
-              ? { border: "1px solid rgba(180,220,255,0.6)" }
+              ? { border: '1px solid rgba(180,220,255,0.6)' }
               : undefined
           )}
         >
           <PixelartIcon
-            iconName="music"
-            className={`audio-icon-fix ${!musicEnabled ? "audio-icon-muted" : ""}`}
+            iconName='music'
+            className={`audio-icon-fix ${musicEnabled ? '' : 'audio-icon-muted'}`}
             width={GLYPH}
           />
         </button>
       </div>
     </>
-  );
+  )
 }

--- a/src/reactUi.tsx
+++ b/src/reactUi.tsx
@@ -54,6 +54,7 @@ import { useAppScale } from './scaleInterface'
 import PacketsReplayProvider from './react/PacketsReplayProvider'
 import TouchInteractionHint from './react/TouchInteractionHint'
 import { ua } from './react/utils'
+import AudioControls from './react/AudioControls'
 
 const isFirefox = ua.getBrowser().name === 'Firefox'
 if (isFirefox) {
@@ -227,6 +228,7 @@ const App = () => {
             <NoModalFoundProvider />
             <PacketsReplayProvider />
             <NotificationProvider />
+            <AudioControls />
           </RobustPortal>
           <RobustPortal to={document.body}>
             <div className='overlay-top-scaled'>


### PR DESCRIPTION
One web, audio would not start until the user clicked into the iframe.
Since our controls were not part of the iframe, the simple solution was to move the audio controls into the iframe, or minecraft-web-client.

This adds the audio controls to the web-client, and removes all iframe messaging related to audio/music.