### PR TITLE
Fix followed player death issue

### DIFF
--- a/src/follow.ts
+++ b/src/follow.ts
@@ -11,8 +11,8 @@ function handleMovement () {
   if (following && !following?.entity?.position) {
     // if the following entity cannot be found, switch back to following the bot itself
     console.log('The entity to follow could no longer be found (left/died/too far away/etc.)')
-    console.log('Switching back to following the bot itself')
-    void setFollowingPlayer()
+    console.log('Alerting parent app')
+    customEvents.emit('followingPlayerLost')
     return
   }
 

--- a/src/globals.d.ts
+++ b/src/globals.d.ts
@@ -32,6 +32,7 @@ declare const customEvents: import('typed-emitter').default<{
   activateItem (item: Item, slot: number, offhand: boolean): void
   hurtAnimation (yaw?: number): void
   followingPlayer (username?: string): void // when following has begun
+  followingPlayerLost (): void // when following player is not longer found
   'kradle:command' (data: any): void // a command to run as the bot
   'kradle:followPlayer' (data: any): void // request from kradle to follow a player
   'kradle:reconnect' (data: any): void // request from kradle to reconnect

--- a/src/iframe.ts
+++ b/src/iframe.ts
@@ -33,6 +33,10 @@ type IFrameSendablePayload =
     source: 'minecraft-web-client';
     action: 'pointerLockReleased';
   }
+  | {
+    source: 'minecraft-web-client';
+    action: 'followingPlayerLost';
+  }
 
 type ReceivableActions = 'followPlayer' | 'command' | 'reconnect' | 'setAgentSkins'
 
@@ -72,6 +76,11 @@ export function setupIframeComms () {
   customEvents.on('pointerLockReleased', () => {
     sendMessageToKradle({
       action: 'pointerLockReleased'
+    })
+  })
+  customEvents.on('followingPlayerLost', () => {
+    sendMessageToKradle({
+      action: 'followingPlayerLost'
     })
   })
   customEvents.on('kradle:command', (data) => {


### PR DESCRIPTION
send event to parent app when we can't find the followed player, instead of going straight to spectator mode