### PR TITLE
Fix camera control in viewerConnect mode

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -636,7 +636,7 @@ export async function connect (connectOptions: ConnectOptions) {
       const VIEWER_IGNORE_PACKETS = new Set(['position', 'synchronize_player_position'])
       let firstPositionReceived = false
       const origEmit = bot._client.emit.bind(bot._client)
-      //@ts-expect-error
+      
       bot._client.emit = (event: string, ...args: any[]) => {
         if (VIEWER_IGNORE_PACKETS.has(event)) {
           if (!firstPositionReceived) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -636,7 +636,13 @@ export async function connect (connectOptions: ConnectOptions) {
       const VIEWER_IGNORE_PACKETS = new Set(['position', 'synchronize_player_position'])
       let firstPositionReceived = false
       const origEmit = bot._client.emit.bind(bot._client)
-      
+
+      bot.once('end', () => {
+        if (bot?._client) {
+          bot._client.emit = origEmit
+        }
+      })
+
       bot._client.emit = (event: string, ...args: any[]) => {
         if (VIEWER_IGNORE_PACKETS.has(event)) {
           if (!firstPositionReceived) {
@@ -647,7 +653,14 @@ export async function connect (connectOptions: ConnectOptions) {
         }
         // Force spectator mode so viewer always gets free camera
         if (event === 'login' && args[0]) {
-          args[0].gameMode = 3 // spectator
+          args[0] = { ...args[0], gameMode: 3 }
+        }
+        if (event === 'respawn' && args[0]) {
+          args[0] = { ...args[0], gameMode: 3 }
+        }
+        // Block server-initiated gamemode changes (reason 3 = change gamemode)
+        if (event === 'game_state_change' && args[0]?.reason === 3) {
+          return true
         }
         return origEmit(event, ...args)
       }

--- a/src/index.ts
+++ b/src/index.ts
@@ -629,6 +629,28 @@ export async function connect (connectOptions: ConnectOptions) {
 
     if (connectOptions.viewerWsConnect) {
       void handleCustomChannel()
+
+      // In viewerConnect mode, let the first position packet through (so the client
+      // knows where to load chunks), then ignore subsequent ones so the viewer
+      // has independent camera control (same as replay mode)
+      const VIEWER_IGNORE_PACKETS = new Set(['position', 'synchronize_player_position'])
+      let firstPositionReceived = false
+      const origEmit = bot._client.emit.bind(bot._client)
+      //@ts-expect-error
+      bot._client.emit = (event: string, ...args: any[]) => {
+        if (VIEWER_IGNORE_PACKETS.has(event)) {
+          if (!firstPositionReceived) {
+            firstPositionReceived = true
+            return origEmit(event, ...args)
+          }
+          return true
+        }
+        // Force spectator mode so viewer always gets free camera
+        if (event === 'login' && args[0]) {
+          args[0].gameMode = 3 // spectator
+        }
+        return origEmit(event, ...args)
+      }
     }
     customEvents.emit('mineflayerBotCreated')
     if (singleplayer || p2pMultiplayer || localReplaySession) {


### PR DESCRIPTION
## Summary
- Filter position/synchronize_player_position packets after the first one so viewers have independent camera control
- Force spectator gamemode (3) in login packet for viewers
- Don't reset camera to birds-eye on Escape in viewerConnect mode

## Test plan
- [ ] Connect via `?viewerConnect=ws://localhost:25588`, verify world loads
- [ ] Verify free camera movement with WASD + mouse
- [ ] Verify pressing Escape doesn't snap camera back to Watcher position
- [ ] Verify reconnecting still gets spectator mode (not survival)

🤖 Generated with [Claude Code](https://claude.com/claude-code)