### PR TITLE
Add detailed mesh children visibility logging

### DIFF
--- a/renderer/viewer/three/entities.ts
+++ b/renderer/viewer/three/entities.ts
@@ -763,8 +763,10 @@ export class Entities {
       console.log('[Entity Debug] Entity created successfully:', {
         id: entity.id,
         name: entity.name,
+        position: { x: entity.pos.x, y: entity.pos.y, z: entity.pos.z },
         inScene: this.worldRenderer.scene.children.includes(group),
-        visible: group.visible
+        visible: group.visible,
+        meshChildrenCount: mesh.children?.length ?? 0
       })
     } else {
       mesh = e.children.find(c => c.name === 'mesh')
@@ -795,6 +797,18 @@ export class Entities {
       if (child.name !== 'nametag') {
         child.visible = !isInvisible
       }
+    }
+
+    // Debug: Log mesh children visibility
+    if (justAdded) {
+      console.log('[Entity Debug] Mesh children visibility:', {
+        id: entity.id,
+        name: entity.name,
+        isInvisible: !!isInvisible,
+        metadata0: entity.metadata?.[0],
+        meshChildrenCount: mesh?.children?.length ?? 0,
+        meshChildrenVisible: mesh?.children?.map(c => ({ name: c.name, visible: c.visible })) ?? []
+      })
     }
     // ---
     // set baby size


### PR DESCRIPTION
## Summary
Adds enhanced logging to diagnose why entities appear in scene but are invisible.

## Debug Info Added
- Entity position (x, y, z) at creation
- Mesh children count and visibility status
- Entity metadata invisibility flag
- Individual child visibility for each mesh component

## Context
Previous PR showed all entities report `inScene: true` and `visible: true`, but 2 out of 6 pigs were still invisible. This logging will reveal if:
- Mesh children are being set to invisible via entity metadata
- Entities are spawning at invalid positions
- There's an issue with mesh geometry/materials

## Changes
- Log position at entity creation
- Log metadata invisibility flag and mesh children details after visibility is set