### PR TITLE
Fix syntax error: missing closing brace

### DIFF
--- a/renderer/viewer/three/entities.ts
+++ b/renderer/viewer/three/entities.ts
@@ -802,7 +802,8 @@ export class Entities {
     // Debug: Log mesh children visibility
     if (justAdded) {
       const childrenInfo = mesh?.children?.map(c => `${c.name}:${c.visible}`).join(', ') ?? 'none'
-      console.log(`[Entity Debug] ID ${entity.id} (${entity.name}) mesh children: [${childrenInfo}], isInvisible=${!!isInvisible}, metadata0=${entity.metadata?.[0]}`)
+      const metadata0 = entity.metadata?.[0] === undefined ? 'undefined' : JSON.stringify(entity.metadata[0])
+      console.log(`[Entity Debug] ID ${entity.id} (${entity.name}) mesh children: [${childrenInfo}], isInvisible=${!!isInvisible}, metadata0=${metadata0}`)
       // Also log if entity group scale is 0 (hidden via scale hack)
       if (e.scale.x === 0 || e.scale.y === 0 || e.scale.z === 0) {
         console.warn(`[Entity Debug] ID ${entity.id} has ZERO SCALE! scale=(${e.scale.x}, ${e.scale.y}, ${e.scale.z})`)

--- a/renderer/viewer/three/entities.ts
+++ b/renderer/viewer/three/entities.ts
@@ -623,6 +623,7 @@ export class Entities {
         pos: { x: entity.pos.x, y: entity.pos.y, z: entity.pos.z },
         hasUsername: !!entity.username
       }))
+    }
 
     const isPlayerModel = entity.name === 'player'
     if (entity.name === 'zombie_villager' || entity.name === 'husk') {


### PR DESCRIPTION
## Summary
Fixes build failure caused by missing closing brace in entity debug logging.

## Error
Previous PR introduced syntax error on line 626 - missing `}` after JSON.stringify call.

## Fix
Add missing closing brace for if statement.