### PR TITLE
Fix websocket packets ordering

### DIFF
--- a/renderer/viewer/three/entities.ts
+++ b/renderer/viewer/three/entities.ts
@@ -794,7 +794,7 @@ export class Entities {
     // set visibility
     const isInvisible = entity.metadata?.[0] & 0x20
     for (const child of mesh.children ?? []) {
-      if (child.name !== 'nametag') {
+      if (child.name !== 'nametag' && !(child instanceof THREE.SkeletonHelper)) {
         child.visible = !isInvisible
       }
     }
@@ -976,8 +976,9 @@ export class Entities {
     const e = this.entities[entity.id]
     if (!e) return
     const ANIMATION_DURATION = justAdded ? 0 : TWEEN_DURATION
-    if (entity.position) {
-      new TWEEN.Tween(e.position).to({ x: entity.position.x, y: entity.position.y, z: entity.position.z }, ANIMATION_DURATION).start()
+    const entityPos = (entity as any).position ?? (entity as any).pos
+    if (entityPos) {
+      new TWEEN.Tween(e.position).to({ x: entityPos.x, y: entityPos.y, z: entityPos.z }, ANIMATION_DURATION).start()
     }
     if (entity.yaw) {
       const da = (entity.yaw - e.rotation.y) % (Math.PI * 2)

--- a/src/mineflayer/websocket-core.ts
+++ b/src/mineflayer/websocket-core.ts
@@ -18,16 +18,24 @@ export const getWebsocketStream = async (host: string) => {
   const baseProtocol = location.protocol === 'https:' ? 'wss' : host.startsWith('ws://') ? 'ws' : 'wss'
   const hostClean = host.replace('ws://', '').replace('wss://', '')
   const ws = new WebSocket(`${baseProtocol}://${hostClean}`)
+  ws.binaryType = 'arraybuffer'
   const clientDuplex = new CustomDuplex(undefined, data => {
     ws.send(data)
   })
 
-  ws.addEventListener('message', async message => {
-    let { data } = message
-    if (data instanceof Blob) {
-      data = await data.arrayBuffer()
-    }
-    clientDuplex.push(Buffer.from(data))
+  // Preserve exact WS frame ordering before feeding minecraft-protocol.
+  // Async Blob conversion can otherwise reorder chunks under load.
+  let messageQueue = Promise.resolve()
+  ws.addEventListener('message', message => {
+    messageQueue = messageQueue.then(async () => {
+      let { data } = message
+      if (data instanceof Blob) {
+        data = await data.arrayBuffer()
+      }
+      clientDuplex.push(Buffer.from(data as ArrayBuffer | string))
+    }).catch((err) => {
+      console.error('ws message processing error', err)
+    })
   })
 
   ws.addEventListener('close', () => {

--- a/src/mineflayer/websocket-core.ts
+++ b/src/mineflayer/websocket-core.ts
@@ -32,7 +32,10 @@ export const getWebsocketStream = async (host: string) => {
       if (data instanceof Blob) {
         data = await data.arrayBuffer()
       }
-      clientDuplex.push(Buffer.from(data as ArrayBuffer | string))
+      const chunk = typeof data === 'string'
+        ? Buffer.from(data)
+        : Buffer.from(new Uint8Array(data))
+      clientDuplex.push(chunk)
     }).catch((err) => {
       console.error('ws message processing error', err)
     })

--- a/src/sounds/audioTrackScheduler.ts
+++ b/src/sounds/audioTrackScheduler.ts
@@ -14,7 +14,7 @@ interface QueuedTrack {
 
 class AudioTrackScheduler {
   private tracks: AudioTrack[] = []
-  private playedTrackIds = new Set<string>()
+  private readonly playedTrackIds = new Set<string>()
   private isPlaying = false
   private currentTimeMs = 0
   private isLoading = false

--- a/src/viewerConnector.ts
+++ b/src/viewerConnector.ts
@@ -74,6 +74,7 @@ const openWebsocket = async (url: string) => {
   if (url.startsWith(':')) url = `ws://localhost${url}`
   if (!url.startsWith('ws')) url = `ws://${url}`
   const ws = new WebSocket(url)
+  ws.binaryType = 'arraybuffer'
   await new Promise<void>((resolve, reject) => {
     ws.onopen = () => resolve()
     ws.onerror = (err) => reject(new Error(`[websocket] Failed to connect to ${url}`))
@@ -90,13 +91,20 @@ export const getWsProtocolStream = async (url: string) => {
   })
   // todo use keep alive instead?
   let lastMessageTime = performance.now()
-  ws.addEventListener('message', async (message) => {
-    let { data } = message
-    if (data instanceof Blob) {
-      data = await data.arrayBuffer()
-    }
-    clientDuplex.push(Buffer.from(data))
-    lastMessageTime = performance.now()
+  // Preserve exact WS frame ordering before feeding minecraft-protocol.
+  // Async Blob conversion can otherwise reorder chunks under load.
+  let messageQueue = Promise.resolve()
+  ws.addEventListener('message', (message) => {
+    messageQueue = messageQueue.then(async () => {
+      let { data } = message
+      if (data instanceof Blob) {
+        data = await data.arrayBuffer()
+      }
+      clientDuplex.push(Buffer.from(data as ArrayBuffer | string))
+      lastMessageTime = performance.now()
+    }).catch((err) => {
+      console.error('[ws] Failed to process incoming frame', err)
+    })
   })
   setInterval(() => {
     // if (clientDuplex.destroyed) return

--- a/src/viewerConnector.ts
+++ b/src/viewerConnector.ts
@@ -100,7 +100,10 @@ export const getWsProtocolStream = async (url: string) => {
       if (data instanceof Blob) {
         data = await data.arrayBuffer()
       }
-      clientDuplex.push(Buffer.from(data as ArrayBuffer | string))
+      const chunk = typeof data === 'string'
+        ? Buffer.from(data)
+        : Buffer.from(new Uint8Array(data))
+      clientDuplex.push(chunk)
       lastMessageTime = performance.now()
     }).catch((err) => {
       console.error('[ws] Failed to process incoming frame', err)


### PR DESCRIPTION
This PR tries to fix entities rendering. The identified issue is that the entity position is wrong, so they are not rendered. I think it's because packets are not ordered correctly when asynchronously parsed to BLOBs. I implemented a queue to hopefully solve the issue.

In addition:
- Sometimes `emtity.position` was used, sometimes `entity.pos` - for the moment I pushed a dirty fix of trying both, I'll fix the core issue later
- SkeletonHelpers (debug lines) would sometimes appear in the web viewer! This PR fixes the issue by skipping it entirely in the rendering loop.