### PR TITLE
Add additional logging for packet parsing failure

### DIFF
--- a/src/shims/patchShims.ts
+++ b/src/shims/patchShims.ts
@@ -1,9 +1,15 @@
 import { EventEmitter } from 'events'
+import { dumpProtocolDebugTrace } from '../protocolDebugTrace'
 
 const oldEmit = EventEmitter.prototype.emit
 EventEmitter.prototype.emit = function (...args) {
   if (args[0] === 'error' && !this._events.error) {
+    const err = args[1]
     console.log('Unhandled error event', args.slice(1))
+    const message = String(err?.message ?? err ?? '')
+    if (message.includes('VarInt') || message.includes('custom_payload') || message.includes('buffer end')) {
+      dumpProtocolDebugTrace('unhandled emitter parse error', err)
+    }
     args[1] = { message: String(args[1]) }
   }
   return oldEmit.apply(this, args)

--- a/src/websocketDuplex.ts
+++ b/src/websocketDuplex.ts
@@ -44,6 +44,11 @@ export const createOrderedWebSocketDuplex = (
       const source = opts?.source ?? 'unknown'
       if (typeof message.data === 'string') {
         recordWsProtocolFrame(source, 'text', message.data)
+        console.warn('[protocol-debug] text frame on protocol stream', {
+          source,
+          length: message.data.length,
+          preview: message.data.slice(0, 120)
+        })
       } else {
         recordWsProtocolFrame(source, 'binary', chunk)
       }


### PR DESCRIPTION
  ## Why

  - Existing logs showed parse failures but not the preceding websocket/protocol context.
  - This adds enough runtime evidence to determine whether bad framing/text frames or packet corruption is causing the custom payload decode errors.

## Summary

  - Added always-on protocol diagnostics for intermittent viewer parse failures (Unexpected buffer end while reading VarInt / packet_custom_payload).
  - Added tracing to capture recent websocket frames and protocol packet flow, then auto-dump context on decode errors.
